### PR TITLE
Feat/#57 イベント参加登録機能の実装

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,163 @@
+### **Gemini Code Assist スタイルガイド (Rails特化版)**
+
+あなたは**Ruby on Railsのシニアエンジニア**です。  
+このスタイルガイドに沿ってコードレビューを徹底的に行なってください。
+
+## **1. 基本方針**
+- **レビュー言語**: すべてのレビューは**日本語**で実施する。  
+- **目的**: Railsの設計原則に基づき、コードの**可読性・保守性・拡張性・セキュリティ・パフォーマンス**を向上させる。  
+- **原則**: Railsのベストプラクティスに従い、一貫性のあるコーディングスタイルを維持する。  
+  - **MVCアーキテクチャの遵守**
+  - **DRY（Don’t Repeat Yourself）**
+  - **KISS（Keep It Simple, Stupid）**
+  - **YAGNI（You Ain’t Gonna Need It）**
+  - **Fat Model, Skinny Controller**
+  - **SOLID原則の適用**
+  
+---
+
+## **2. Rails向けコードレビュー項目**
+### **2.1 コード品質・設計**
+✅ **適切な命名規則**
+- クラス名は **CamelCase**
+- メソッド・変数名は **snake_case**
+- DBのカラム名は **snake_case**
+- Booleanメソッドは **`?`をつける**（例: `user.active?`）
+- バングメソッド（破壊的メソッド）には **`!`をつける**（例: `user.save!`）
+
+✅ **シンプルで明快なコード**
+- 複雑なロジックは **Service Object, Decorator, Query Object** へ分離  
+- Fat Controllerになっていないか  
+- Modelの責務が適切に分割されているか（特に**コールバックの乱用を避ける**）  
+- ヘルパーメソッドが乱立していないか（適切なView Componentの利用を検討）
+
+✅ **バリデーション・コールバックの適正化**
+- **モデルのコールバックは最小限に**
+- `before_save` や `after_save` の乱用を避け、必要なら**Service Objectを利用**
+- **ActiveRecordのバリデーションは適切か**
+
+✅ **マジックナンバーを使わない**
+- 定数や`enum`を適切に利用する
+- 例：
+  ```ruby
+  class User < ApplicationRecord
+    enum role: { guest: 0, member: 1, admin: 2 }
+  end
+  ```
+
+---
+
+### **2.2 保守性・拡張性**
+✅ **Fat Controller/Fat Modelになっていないか**
+- **Service Object, Decorator, Form Object, Query Object** の活用を検討  
+- 例：Fat Controllerのリファクタリング
+  ```ruby
+  # Fat Controller
+  class OrdersController < ApplicationController
+    def create
+      @order = Order.new(order_params)
+      if @order.save
+        OrderMailer.confirmation(@order).deliver_now
+        render json: { message: 'Success' }
+      else
+        render json: { errors: @order.errors.full_messages }, status: :unprocessable_entity
+      end
+    end
+  end
+
+  # Service Objectへ分離
+  class OrderCreator
+    def initialize(order_params)
+      @order_params = order_params
+    end
+
+    def call
+      order = Order.new(@order_params)
+      if order.save
+        OrderMailer.confirmation(order).deliver_now
+        order
+      else
+        nil
+      end
+    end
+  end
+  ```
+
+✅ **N+1問題が発生していないか**
+- `.includes`, `.joins`, `.preload` を適切に利用する
+- 例：
+  ```ruby
+  # NG: N+1発生
+  users = User.all
+  users.each do |user|
+    puts user.posts.count
+  end
+
+  # OK: includesを利用
+  users = User.includes(:posts)
+  users.each do |user|
+    puts user.posts.size
+  end
+  ```
+
+✅ **テストカバレッジ**
+- **Rspecでの単体テストがあるか**
+- **FactoryBotの適切な利用**
+
+---
+
+### **2.3 パフォーマンス**
+✅ **適切なスコープを定義しているか**
+```ruby
+# NG
+def self.active_users
+  where(active: true)
+end
+
+# OK: scopeを使用
+scope :active, -> { where(active: true) }
+```
+
+✅ **キャッシュの活用**
+- フラグメントキャッシュ、Rails.cache、Redisの適切な使用
+- `low_card_tables` や `counter_cache` を検討
+
+---
+
+### **2.4 セキュリティ**
+✅ **SQLインジェクション対策**
+- プレースホルダーを使ったクエリを書く
+  ```ruby
+  # NG
+  User.where("email = '#{params[:email]}'")
+
+  # OK
+  User.where(email: params[:email])
+  ```
+
+✅ **CSRF/XSS対策**
+- `protect_from_forgery` を適用
+- `html_safe` の乱用を避ける
+
+✅ **Strong Parametersの適切な使用**
+- `params.require(:user).permit(:name, :email, :password)`
+
+---
+
+## **3. Rails特化レビューコメントの書き方**
+✅ **具体的なコード例を添える**
+- NG: 「この処理はパフォーマンスが悪いです」
+- OK: 「この処理はN+1問題を引き起こします。`includes(:posts)` を使いましょう」
+
+✅ **公式ドキュメントの参照**
+- 例：「このバリデーションには`Rails Guides` の[Active Record Validations](https://guides.rubyonrails.org/active_record_validations.html)を参照してください。」
+
+✅ **可読性・保守性の観点から指摘**
+- 「このメソッドは長すぎるので、Service Objectに分離しましょう」
+
+---
+
+## **4. その他の注意事項**
+- **プロジェクトのWIKIやissueを確認**し、既存の設計方針に沿っているか検討
+- **軽微なコードスタイルの指摘は最小限に**し、本質的な改善にフォーカスする
+- **実装者と適切な意見交換**を行い、単なる批評ではなく建設的なフィードバックを心掛ける

--- a/app/controllers/event_participants_controller.rb
+++ b/app/controllers/event_participants_controller.rb
@@ -1,0 +1,39 @@
+class EventParticipantsController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    @event_participant = EventParticipant.new
+  end
+
+  # 参加登録は current_user 前提（他人の登録はさせない）
+  def create
+    service = EventRegistrationService.new(current_user, event)
+    begin
+      service.create_registration!
+      flash[:notice] = "参加登録が完了しました。"
+    rescue ActiveRecord::RecordInvalid => e
+      flash[:alert] = e.record.errors.full_messages.join(", ")
+    end
+    redirect_to event_path(event)
+  end
+
+  def destroy
+    participant = EventParticipant.find(params[:id])
+
+    # TODO: 削除時にcurrent_userを渡す必要ないのでクラスを分けるなりする
+    service = EventRegistrationService.new(current_user, event)
+    begin
+      service.destroy_participant!(participant)
+      flash[:notice] = "参加登録を削除しました。"
+    rescue ActiveRecord::RecordInvalid => e
+      flash[:alert] = e.record.errors.full_messages.join(", ")
+    end
+    redirect_to event_path(event)
+  end
+
+  private
+
+  def event
+    @event ||= Event.find(params[:event_id])
+  end
+end

--- a/app/controllers/event_participants_controller.rb
+++ b/app/controllers/event_participants_controller.rb
@@ -7,6 +7,9 @@ class EventParticipantsController < ApplicationController
 
   # 参加登録は current_user 前提（他人の登録はさせない）
   def create
+    new_participant = EventParticipant.new(user: current_user, event: event)
+    authorize new_participant
+
     service = EventRegistrationService.new(current_user, event)
     begin
       service.create_registration!
@@ -19,6 +22,7 @@ class EventParticipantsController < ApplicationController
 
   def destroy
     participant = EventParticipant.find(params[:id])
+    authorize participant
 
     # TODO: 削除時にcurrent_userを渡す必要ないのでクラスを分けるなりする
     service = EventRegistrationService.new(current_user, event)

--- a/app/controllers/event_waitlists_controller.rb
+++ b/app/controllers/event_waitlists_controller.rb
@@ -1,0 +1,19 @@
+class EventWaitlistsController < ApplicationController
+  before_action :authenticate_user!
+
+  def destroy
+    waitlist = EventWaitlist.find(params[:id])
+
+    # TODO: 削除時にcurrent_userを渡す必要ないのでクラスを分けるなりする
+    service = EventRegistrationService.new(current_user, event)
+    service.destroy_waitlist!(waitlist)
+    flash[:notice] = "補欠登録を削除しました。"
+    redirect_to event_path(event)
+  end
+
+  private
+
+  def event
+    @event ||= Event.find(params[:event_id])
+  end
+end

--- a/app/controllers/event_waitlists_controller.rb
+++ b/app/controllers/event_waitlists_controller.rb
@@ -3,6 +3,7 @@ class EventWaitlistsController < ApplicationController
 
   def destroy
     waitlist = EventWaitlist.find(params[:id])
+    authorize waitlist
 
     # TODO: 削除時にcurrent_userを渡す必要ないのでクラスを分けるなりする
     service = EventRegistrationService.new(current_user, event)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,7 +8,7 @@ class EventsController < ApplicationController
 
   def show
     @event = Event.includes(event_participants: :user, event_waitlists: :user).find(params[:id])
-    authorize event
+    authorize @event
   end
 
   def new

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,6 +7,7 @@ class EventsController < ApplicationController
   end
 
   def show
+    @event = Event.includes(event_participants: :user, event_waitlists: :user).find(params[:id])
     authorize event
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,12 @@
 class Event < ApplicationRecord
   belongs_to :eventable, polymorphic: true
 
+  has_many :event_participants, dependent: :destroy
+  has_many :participants, through: :event_participants, source: :user
+
+  has_many :event_waitlists, dependent: :destroy
+  has_many :waitlisted_users, through: :event_waitlists, source: :user
+
   validates :title, presence: true
   validates :event_start_at, presence: true
   validates :event_end_at, presence: true, comparison: { greater_than: :event_start_at }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -25,6 +25,14 @@ class Event < ApplicationRecord
     participants.count >= max_participants
   end
 
+  def registered?(user)
+    participants.include?(user) || waitlisted_users.include?(user)
+  end
+
+  def registration_for(user)
+    event_participants.find_by(user: user) || event_waitlists.find_by(user: user)
+  end
+
   private
 
   def event_start_after_recruitment_start

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,6 +20,11 @@ class Event < ApplicationRecord
   validate :event_start_cannot_be_in_past, if: -> { event_start_at.present? }
   validate :recruitment_start_cannot_be_in_past, if: -> { recruitment_start_at.present? }
 
+  def full?
+    return false if max_participants.nil?
+    participants.count >= max_participants
+  end
+
   private
 
   def event_start_after_recruitment_start

--- a/app/models/event_participant.rb
+++ b/app/models/event_participant.rb
@@ -1,0 +1,4 @@
+class EventParticipant < ApplicationRecord
+  belongs_to :user
+  belongs_to :event
+end

--- a/app/models/event_participant.rb
+++ b/app/models/event_participant.rb
@@ -1,4 +1,13 @@
 class EventParticipant < ApplicationRecord
   belongs_to :user
   belongs_to :event
+
+  validates :user_id, uniqueness: { scope: :event_id, message: :already_participant }
+  validate :not_in_waitlist
+
+  private
+
+  def not_in_waitlist
+    errors.add(:user_id, :already_on_waitlist) if EventWaitlist.exists?(user: user, event: event)
+  end
 end

--- a/app/models/event_waitlist.rb
+++ b/app/models/event_waitlist.rb
@@ -1,4 +1,13 @@
 class EventWaitlist < ApplicationRecord
   belongs_to :user
   belongs_to :event
+
+  validates :user_id, uniqueness: { scope: :event_id, message: :already_on_waitlist }
+  validate :not_a_participant
+
+  private
+
+  def not_a_participant
+    errors.add(:user_id, :already_participant) if EventParticipant.exists?(user: user, event: event)
+  end
 end

--- a/app/models/event_waitlist.rb
+++ b/app/models/event_waitlist.rb
@@ -1,0 +1,4 @@
+class EventWaitlist < ApplicationRecord
+  belongs_to :user
+  belongs_to :event
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,5 +7,12 @@ class User < ApplicationRecord
   has_many :event_groups # 作成したグループ
   has_many :event_group_admins
   has_many :administered_groups, through: :event_group_admins, source: :event_group # 管理者になってるグループ
+
   has_many :events, as: :eventable
+
+  has_many :event_participants
+  has_many :participating_events, through: :event_participants, source: :event
+
+  has_many :event_waitlists
+  has_many :waitlisted_events, through: :event_waitlists, source: :event
 end

--- a/app/policies/event_participant_policy.rb
+++ b/app/policies/event_participant_policy.rb
@@ -1,0 +1,27 @@
+class EventParticipantPolicy < ApplicationPolicy
+  def new?
+    true
+  end
+
+  def create?
+    new?
+  end
+
+  def destroy?
+    record.user == user || event_admin?
+  end
+
+  private
+
+  def event_admin?
+    event = record.event
+    case event.eventable
+    when EventGroup
+      event.eventable.admin?(user)
+    when User
+      event.eventable == user
+    else
+      false
+    end
+  end
+end

--- a/app/policies/event_waitlist_policy.rb
+++ b/app/policies/event_waitlist_policy.rb
@@ -1,0 +1,19 @@
+class EventWaitlistPolicy < ApplicationPolicy
+  def destroy?
+    record.user == user || event_admin?
+  end
+
+  private
+
+  def event_admin?
+    event = record.event
+    case event.eventable
+    when EventGroup
+      event.eventable.admin?(user)
+    when User
+      event.eventable == user
+    else
+      false
+    end
+  end
+end

--- a/app/services/event_registration_service.rb
+++ b/app/services/event_registration_service.rb
@@ -47,9 +47,7 @@ class EventRegistrationService
     next_waitlist_user = EventWaitlist.where(event: event).order(:created_at).first
     return unless next_waitlist_user
 
-    ActiveRecord::Base.transaction do
-      next_waitlist_user.destroy!
-      EventParticipant.create!(user: next_waitlist_user.user, event: event)
-    end
+    next_waitlist_user.destroy!
+    EventParticipant.create!(user: next_waitlist_user.user, event: event)
   end
 end

--- a/app/services/event_registration_service.rb
+++ b/app/services/event_registration_service.rb
@@ -1,0 +1,55 @@
+class EventRegistrationService
+  private attr_reader :user, :event
+
+  def initialize(user, event)
+    @user = user
+    @event = event
+  end
+
+  # 参加 or 補欠登録
+  def create_registration!
+    ActiveRecord::Base.transaction do
+      if event.full?
+        create_waitlist!
+      else
+        create_participant!
+      end
+    end
+  end
+
+  # 参加を削除して補欠繰り上げ
+  def destroy_participant!(participant)
+    ActiveRecord::Base.transaction do
+      participant.destroy!
+      promote_waitlist_user!
+    end
+  end
+
+  # 補欠を削除
+  def destroy_waitlist!(waitlist)
+    waitlist.destroy!
+  end
+
+  private
+
+  def create_participant!
+    EventParticipant.create!(user: user, event: event)
+  end
+
+  def create_waitlist!
+    EventWaitlist.create!(user: user, event: event)
+  end
+
+  # キャンセル時に先頭の補欠ユーザーを昇格させる
+  def promote_waitlist_user!
+    return if event.full?
+
+    next_waitlist_user = EventWaitlist.where(event: event).order(:created_at).first
+    return unless next_waitlist_user
+
+    ActiveRecord::Base.transaction do
+      next_waitlist_user.destroy!
+      EventParticipant.create!(user: next_waitlist_user.user, event: event)
+    end
+  end
+end

--- a/app/views/event_participants/new.html.erb
+++ b/app/views/event_participants/new.html.erb
@@ -1,0 +1,26 @@
+<h1>参加登録</h1>
+
+<p>以下のイベントに参加登録します。</p>
+<p>
+  <strong>イベントタイトル:</strong>
+  <%= @event.title %>
+</p>
+
+<%= form_with model: @event_participant, url: event_participants_path(@event), data: { turbo: true } do |form| %>
+  <% if @event_participant.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@event_participant.errors.count, "error") %> 参加登録に失敗しました:</h2>
+      <ul>
+        <% @event_participant.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= form.submit "参加登録する" %>
+  </div>
+<% end %>
+
+<%= link_to 'キャンセル', event_path(@event) %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -5,7 +5,27 @@
 <%= link_to '編集', edit_event_path(@event) %>
 <%= link_to '削除', event_path(@event), method: :delete, data: { turbo_method: :delete, turbo_confirm: '削除してよろしいですか?' } %>
 
+<% if @event.registered?(current_user) %>
+  <% registration = @event.registration_for(current_user) %>
+  <% if registration.is_a?(EventParticipant) %>
+    <%= link_to '参加登録キャンセル', participant_path(registration, event_id: @event.id),
+        method: :delete,
+        data: { turbo_method: :delete, turbo_confirm: '本当にキャンセルしてよろしいですか?' },
+        class: 'btn btn-warning' %>
+  <% elsif registration.is_a?(EventWaitlist) %>
+    <%= link_to '補欠登録キャンセル', waitlist_path(registration, event_id: @event.id),
+        method: :delete,
+        data: { turbo_method: :delete, turbo_confirm: '本当にキャンセルしてよろしいですか?' },
+        class: 'btn btn-warning' %>
+  <% end %>
+<% else %>
+  <%= link_to '参加登録', new_event_participant_path(event_id: @event.id),
+      data: { turbo: true },
+      class: 'btn btn-primary' %>
+<% end %>
 
+
+<h3>イベント情報</h3>
 <p>
   <strong>タイトル:</strong>
   <%= @event.title %>
@@ -60,3 +80,17 @@
   <strong>ステータス:</strong>
   <%= @event.status %>
 </p>
+
+<h3>参加者一覧</h3>
+<ul>
+  <% @event.event_participants.each do |participant| %>
+    <li><%= participant.user.email %></li>
+  <% end %>
+</ul>
+
+<h3>補欠者一覧</h3>
+<ul>
+  <% @event.event_waitlists.each do |waitlist| %>
+    <li><%= waitlist.user.email %></li>
+  <% end %>
+</ul>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -83,6 +83,8 @@
 
 <h3>参加者一覧</h3>
 <ul>
+  <%# NOTE: この処理は大量のレコードがある場合にパフォーマンス問題を引き起こす可能性がある %>
+  <%# 将来的にはバッチ処理やページネーションの導入を検討する %>
   <% @event.event_participants.each do |participant| %>
     <li><%= participant.user.email %></li>
   <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,7 @@ module MurasameEventMatching
         routing_specs: false
       g.helper false
     end
+
+    config.action_dispatch.rescue_responses["Pundit::NotAuthorizedError"] = :forbidden
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,28 @@
 ja:
   activerecord:
+    models:
+      user: "ユーザー"
+      event_group: "イベントグループ"
+      event: "イベント"
+      event_group_admin: "イベントグループ管理者"
+      event_participant: "イベント参加者"
+      event_waitlist: "イベント補欠"
+    attributes:
+      event_group:
+        name: イベントグループ名
+        description: イベントグループ説明
+      event:
+        name: イベント名
+        description: イベント説明
+        event_start_at: イベント開始日時
+        event_end_at: イベント終了日時
+        recruitment_start_at: 募集開始日時
+        recruitment_closed_at: 募集締切日時
+        max_participants: 最大参加者数
+      event_participant:
+        user: "ユーザー"
+      event_waitlist:
+        user: "ユーザー"
     errors:
       messages:
         required: "を入力してください。"
@@ -18,3 +41,15 @@ ja:
             max_participants:
               not_a_number: "は数値でなければなりません。"
               greater_than: "は0より大きい値にしてください。"
+        event_participant:
+          attributes:
+            user_id:
+              already_participant: "は既に参加者として登録されています。"
+              already_on_waitlist: "は既に補欠リストに存在します。"
+        event_waitlist:
+          attributes:
+            user_id:
+              already_participant: "は既に参加者として登録されています。"
+              already_on_waitlist: "は既に補欠リストに存在します。"
+              
+          

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,10 @@ Rails.application.routes.draw do
   resource :dashboard, only: %i[show]
   resources :event_groups do
     resources :event_group_admins, only: %i[index new create destroy]
-    resources :events, shallow: true
+    resources :events, shallow: true do
+      resources :participants, only: [:new, :create, :destroy], controller: 'event_participants'
+      resources :waitlists, only: [:destroy], controller: 'event_waitlists'
+    end
   end
   # TODO: 個人イベントのルーティング
 end

--- a/db/migrate/20250210022620_create_event_participants.rb
+++ b/db/migrate/20250210022620_create_event_participants.rb
@@ -1,0 +1,12 @@
+class CreateEventParticipants < ActiveRecord::Migration[8.0]
+  def change
+    create_table :event_participants do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :event, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :event_participants, [:event_id, :user_id], unique: true
+  end
+end

--- a/db/migrate/20250210022711_create_event_waitlists.rb
+++ b/db/migrate/20250210022711_create_event_waitlists.rb
@@ -1,0 +1,13 @@
+class CreateEventWaitlists < ActiveRecord::Migration[8.0]
+  def change
+    create_table :event_waitlists do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :event, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :event_waitlists, [:event_id, :user_id], unique: true
+    add_index :event_waitlists, [:event_id, :created_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_04_014746) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_10_022711) do
   create_table "event_group_admins", force: :cascade do |t|
     t.integer "event_group_id", null: false
     t.integer "user_id", null: false
@@ -30,6 +30,27 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_04_014746) do
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_event_groups_on_name"
     t.index ["user_id"], name: "index_event_groups_on_user_id"
+  end
+
+  create_table "event_participants", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "event_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id", "user_id"], name: "index_event_participants_on_event_id_and_user_id", unique: true
+    t.index ["event_id"], name: "index_event_participants_on_event_id"
+    t.index ["user_id"], name: "index_event_participants_on_user_id"
+  end
+
+  create_table "event_waitlists", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "event_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id", "created_at"], name: "index_event_waitlists_on_event_id_and_created_at"
+    t.index ["event_id", "user_id"], name: "index_event_waitlists_on_event_id_and_user_id", unique: true
+    t.index ["event_id"], name: "index_event_waitlists_on_event_id"
+    t.index ["user_id"], name: "index_event_waitlists_on_user_id"
   end
 
   create_table "events", force: :cascade do |t|
@@ -73,4 +94,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_04_014746) do
   add_foreign_key "event_group_admins", "event_groups"
   add_foreign_key "event_group_admins", "users"
   add_foreign_key "event_groups", "users"
+  add_foreign_key "event_participants", "events"
+  add_foreign_key "event_participants", "users"
+  add_foreign_key "event_waitlists", "events"
+  add_foreign_key "event_waitlists", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,67 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+# ユーザーを作成
+users = [
+  User.find_or_create_by!(email: 'alice@example.com') do |user|
+    user.display_name = 'アリス'
+    user.password = 'password'
+  end,
+  User.find_or_create_by!(email: 'bob@example.com') do |user|
+    user.display_name = 'ボブ'
+    user.password = 'password'
+  end,
+  User.find_or_create_by!(email: 'charlie@example.com') do |user|
+    user.display_name = 'チャーリー'
+    user.password = 'password'
+  end
+]
+
+# イベントグループを作成
+event_groups = [
+  EventGroup.find_or_create_by!(name: 'テックカンファレンス') do |group|
+    group.description = 'テクノロジーに関連するイベント'
+    group.image_url = 'https://example.com/image1.jpg'
+    group.user = users[0]
+  end,
+  EventGroup.find_or_create_by!(name: 'ミュージックフェスティバル') do |group|
+    group.description = '音楽に関連するイベント'
+    group.image_url = 'https://example.com/image2.jpg'
+    group.user = users[1]
+  end
+]
+
+# イベントグループの管理者を割り当て
+[
+  { event_group: event_groups[0], user: users[0] },
+  { event_group: event_groups[1], user: users[1] }
+].each do |eg_admin|
+  EventGroupAdmin.find_or_create_by!(event_group: eg_admin[:event_group], user: eg_admin[:user])
+end
+
+# イベントを作成
+events = [
+  Event.find_or_create_by!(title: 'RubyConf 2025') do |event|
+    event.subtitle = 'Ruby on Rails カンファレンス'
+    event.description = 'Ruby愛好家のためのカンファレンスです。'
+    event.image_url = 'https://example.com/event1.jpg'
+    event.event_start_at = Date.current + 1.day
+    event.event_end_at = Date.current + 2.days
+    event.recruitment_start_at = Date.current
+    event.recruitment_closed_at = Date.current + 1.day
+    event.location = 'サンフランシスコ, CA'
+    event.max_participants = 300
+    event.status = :published
+    event.eventable = event_groups[0]
+  end,
+  Event.find_or_create_by!(title: 'サマービーツ') do |event|
+    event.subtitle = '音楽フェスティバル'
+    event.description = '夏の音楽フェスティバルです。'
+    event.image_url = 'https://example.com/event2.jpg'
+    event.event_start_at = Date.current + 1.day
+    event.event_end_at = Date.current + 2.days
+    event.recruitment_start_at = Date.current
+    event.recruitment_closed_at = Date.current + 1.day
+    event.location = 'オースティン, TX'
+    event.max_participants = 500
+    event.status = :draft
+    event.eventable = event_groups[1]
+  end
+]

--- a/spec/factories/event_participants.rb
+++ b/spec/factories/event_participants.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :event_participant do
-    user { nil }
-    event { nil }
+    association :user
+    association :event
   end
 end

--- a/spec/factories/event_participants.rb
+++ b/spec/factories/event_participants.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :event_participant do
+    user { nil }
+    event { nil }
+  end
+end

--- a/spec/factories/event_waitlists.rb
+++ b/spec/factories/event_waitlists.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :event_waitlist do
+    association :user
+    association :event
+  end
+end

--- a/spec/models/event_participant_spec.rb
+++ b/spec/models/event_participant_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe EventParticipant, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/event_participant_spec.rb
+++ b/spec/models/event_participant_spec.rb
@@ -1,5 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe EventParticipant, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーション' do
+    let(:user) { create(:user) }
+    let(:event) { create(:event) }
+    subject { build(:event_participant, user: user, event: event) }
+
+    context 'ユーザーが既にイベントの参加者である場合' do
+      before do
+        create(:event_participant, user: user, event: event)
+      end
+
+      it 'バリデーションに失敗すること' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:user_id]).to include('は既に参加者として登録されています。')
+      end
+    end
+
+    context 'ユーザーが補欠リストに存在する場合' do
+      before do
+        create(:event_waitlist, user: user, event: event)
+      end
+
+      it 'バリデーションに失敗すること' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:user_id]).to include('は既に補欠リストに存在します。')
+      end
+    end
+
+    context 'ユーザーが参加者でも補欠リストにも存在しない場合' do
+      it 'バリデーションを通過すること' do
+        expect(subject).to be_valid
+      end
+    end
+  end
 end

--- a/spec/models/event_waitlist_spec.rb
+++ b/spec/models/event_waitlist_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe EventWaitlist, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/event_waitlist_spec.rb
+++ b/spec/models/event_waitlist_spec.rb
@@ -1,5 +1,39 @@
 require 'rails_helper'
 
 RSpec.describe EventWaitlist, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーション' do
+    let(:user) { create(:user) }
+    let(:event) { create(:event) }
+    subject { build(:event_waitlist, user: user, event: event)  }
+
+    context 'ユーザーが既に参加者である場合' do
+      before do
+        create(:event_participant, user: user, event: event)
+      end
+
+      it 'バリデーションに失敗すること' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:user_id]).to include('は既に参加者として登録されています。')
+      end
+    end
+
+    context 'ユーザーが参加者でない場合' do
+      context 'ユーザーが補欠リストにいない場合' do
+        it 'バリデーションを通過すること' do
+          expect(subject).to be_valid
+        end
+      end
+
+      context 'ユーザーが補欠リストにいる場合' do
+        before do
+          create(:event_waitlist, user: user, event: event)
+        end
+
+        it 'バリデーションに失敗すること' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:user_id]).to include('は既に補欠リストに存在します。')
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/event_participants_spec.rb
+++ b/spec/requests/event_participants_spec.rb
@@ -3,26 +3,85 @@ require 'rails_helper'
 RSpec.describe "EventParticipants", type: :request do
   let(:event) { create(:event) }
   let(:user)  { create(:user) }
+  let(:other_user) { create(:user) }
 
   before { sign_in user }
 
-  describe "POST /create" do
-    it "参加登録されること" do
-      expect {
-        post event_participants_path(event)
-      }.to change(EventParticipant, :count).by(1)
-      expect(response).to redirect_to(event_path(event))
+  describe "GET /new" do
+    it '200 OKが返されること' do
+      get new_event_participant_path(event)
+      expect(response).to have_http_status(200)
     end
   end
 
-  describe "DELETE /destroy" do
-    let!(:participant) { create(:event_participant, user: user, event: event) }
+  describe "POST /create" do
+    context "グループイベントの場合" do
+      let(:group) { create(:event_group) }
+      let(:event) { create(:event, eventable: group) }
 
-    it "参加登録が削除されること" do
-      expect {
-        delete participant_path(participant), params: { event_id: event.id }
-      }.to change(EventParticipant, :count).by(-1)
-      expect(response).to redirect_to(event_path(event))
+      it "参加登録されること" do
+        expect {
+          post event_participants_path(event)
+        }.to change(EventParticipant, :count).by(1)
+        expect(response).to redirect_to(event_path(event))
+      end
+   end
+  end
+
+  describe "DELETE /destroy" do
+    context "グループイベントの場合" do
+      let(:group) { create(:event_group) }
+      let(:event) { create(:event, eventable: group) }
+
+      context "自分の参加登録の場合" do
+        let!(:participant) { create(:event_participant, user: user, event: event) }
+
+        it "自分の参加登録が削除されること" do
+          expect {
+            delete participant_path(participant), params: { event_id: event.id }
+          }.to change(EventParticipant, :count).by(-1)
+          expect(response).to redirect_to(event_path(event))
+        end
+      end
+
+      context "イベント管理者の場合" do
+        before do
+          create(:event_group_admin, user: user, event_group: group)
+        end
+
+        let!(:participant) { create(:event_participant, user: other_user, event: event) }
+
+        it "他人の参加登録でも削除できること" do
+          expect {
+            delete participant_path(participant), params: { event_id: event.id }
+          }.to change(EventParticipant, :count).by(-1)
+          expect(response).to redirect_to(event_path(event))
+        end
+      end
+
+      context "イベント管理者ではない場合" do
+        let(:other_user) { create(:user) }
+        let!(:participant) { create(:event_participant, user: other_user, event: event) }
+
+        it "他人の参加登録は削除できず 403 Forbidden を返すこと" do
+          expect {
+            delete participant_path(participant), params: { event_id: event.id }
+          }.not_to change(EventParticipant, :count)
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+    context "個人イベントの場合" do
+      context "自分の参加登録の場合" do
+        it "自分の参加登録が削除されること" do
+        end
+      end
+
+      context "他人の参加登録の場合" do
+        it "削除できず 403 Forbidden を返すこと" do
+        end
+      end
     end
   end
 end

--- a/spec/requests/event_participants_spec.rb
+++ b/spec/requests/event_participants_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe "EventParticipants", type: :request do
+  let(:event) { create(:event) }
+  let(:user)  { create(:user) }
+
+  before { sign_in user }
+
+  describe "POST /create" do
+    it "参加登録されること" do
+      expect {
+        post event_participants_path(event)
+      }.to change(EventParticipant, :count).by(1)
+      expect(response).to redirect_to(event_path(event))
+    end
+  end
+
+  describe "DELETE /destroy" do
+    let!(:participant) { create(:event_participant, user: user, event: event) }
+
+    it "参加登録が削除されること" do
+      expect {
+        delete participant_path(participant), params: { event_id: event.id }
+      }.to change(EventParticipant, :count).by(-1)
+      expect(response).to redirect_to(event_path(event))
+    end
+  end
+end

--- a/spec/requests/event_waitlists_spec.rb
+++ b/spec/requests/event_waitlists_spec.rb
@@ -1,19 +1,65 @@
 require 'rails_helper'
 
 RSpec.describe "EventWaitlists", type: :request do
-  let(:event) { create(:event) }
-  let(:user)  { create(:user) }
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
 
   before { sign_in user }
 
   describe "DELETE /destroy" do
-    let!(:waitlist) { create(:event_waitlist, user: user, event: event) }
+    context "グループイベントの場合" do
+      let(:group) { create(:event_group) }
+      let(:event) { create(:event, eventable: group) }
 
-    it "補欠登録が削除されること" do
-      expect {
-        delete waitlist_path(waitlist), params: { event_id: event.id }
-      }.to change(EventWaitlist, :count).by(-1)
-      expect(response).to redirect_to(event_path(event))
+      context "自分の補欠登録の場合" do
+        let!(:waitlist) { create(:event_waitlist, user: user, event: event) }
+
+        it "自分の補欠登録が削除されること" do
+          expect {
+            delete waitlist_path(waitlist), params: { event_id: event.id }
+          }.to change(EventWaitlist, :count).by(-1)
+          expect(response).to redirect_to(event_path(event))
+        end
+      end
+
+      context "イベント管理者の場合" do
+        before do
+          create(:event_group_admin, user: user, event_group: group)
+        end
+
+        let!(:waitlist) { create(:event_waitlist, user: other_user, event: event) }
+
+        it "他人の補欠登録でも削除できること" do
+          expect {
+            delete waitlist_path(waitlist), params: { event_id: event.id }
+          }.to change(EventWaitlist, :count).by(-1)
+          expect(response).to redirect_to(event_path(event))
+        end
+      end
+
+      context "イベント管理者ではない場合" do
+        let(:other_user) { create(:user) }
+        let!(:waitlist) { create(:event_waitlist, user: other_user, event: event) }
+
+        it "他人の補欠登録は削除できず 403 Forbidden を返すこと" do
+          expect {
+            delete waitlist_path(waitlist), params: { event_id: event.id }
+          }.not_to change(EventWaitlist, :count)
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+    context "個人イベントの場合" do
+      context "自分の補欠登録の場合" do
+        it "自分の補欠登録が削除されること" do
+        end
+      end
+
+      context "他人の補欠登録の場合" do
+        it "削除できず 403 Forbidden を返すこと" do
+        end
+      end
     end
   end
 end

--- a/spec/requests/event_waitlists_spec.rb
+++ b/spec/requests/event_waitlists_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe "EventWaitlists", type: :request do
+  let(:event) { create(:event) }
+  let(:user)  { create(:user) }
+
+  before { sign_in user }
+
+  describe "DELETE /destroy" do
+    let!(:waitlist) { create(:event_waitlist, user: user, event: event) }
+
+    it "補欠登録が削除されること" do
+      expect {
+        delete waitlist_path(waitlist), params: { event_id: event.id }
+      }.to change(EventWaitlist, :count).by(-1)
+      expect(response).to redirect_to(event_path(event))
+    end
+  end
+end

--- a/spec/services/event_registration_service_spec.rb
+++ b/spec/services/event_registration_service_spec.rb
@@ -1,0 +1,64 @@
+RSpec.describe EventRegistrationService, type: :model do
+  let(:event) { create(:event, max_participants: 1) }
+  let(:user1) { create(:user) }
+  let(:user2) { create(:user) }
+
+  describe "#create_registration!" do
+    context "定員に余裕がある場合" do
+      it "EventParticipantが作成される" do
+        service = EventRegistrationService.new(user1, event)
+        expect { service.create_registration! }.to change(EventParticipant, :count).by(1)
+        expect(EventWaitlist.count).to eq(0)
+      end
+    end
+
+    context "定員がいっぱいの場合" do
+      before do
+        # user1 ですでに参加1人 (max_participants=1)
+        EventParticipant.create!(user: user1, event: event)
+      end
+
+      it "EventWaitlistが作成される" do
+        service = EventRegistrationService.new(user2, event)
+        expect { service.create_registration! }.to change(EventWaitlist, :count).by(1)
+      end
+    end
+  end
+
+  describe "#destroy_participant!" do
+    let!(:participant1) { EventParticipant.create!(user: user1, event: event) }
+
+    context "補欠がいる場合" do
+      let!(:waitlist) { EventWaitlist.create!(user: user2, event: event) }
+
+      it "参加を削除すると補欠が繰り上がる" do
+        service = EventRegistrationService.new(user1, event)
+        expect {
+          service.destroy_participant!(participant1)
+        }.to change(EventParticipant, :count).by(0) # 最初に1人、消して+繰り上げ→合計1人のまま
+        expect(EventParticipant.last.user).to eq(user2)
+        expect(EventWaitlist.count).to eq(0)
+      end
+    end
+
+    context "補欠がいない場合" do
+      it "単に削除されるだけ" do
+        service = EventRegistrationService.new(user1, event)
+        expect {
+          service.destroy_participant!(participant1)
+        }.to change(EventParticipant, :count).by(-1)
+      end
+    end
+  end
+
+  describe "#destroy_waitlist!" do
+    let!(:waitlist) { EventWaitlist.create!(user: user2, event: event) }
+
+    it "waitlistを削除する" do
+      service = EventRegistrationService.new(user1, event)
+      expect {
+        service.destroy_waitlist!(waitlist)
+      }.to change(EventWaitlist, :count).by(-1)
+    end
+  end
+end


### PR DESCRIPTION
## やったこと
issue #57
イベント参加登録機能を実装。
この実装により、ユーザーはイベントへの参加登録と補欠登録が可能となり、キャンセル時には自動で補欠から参加への昇格が行われる。  

- **モデルの追加**  
  - `EventParticipant` と `EventWaitlist` モデルを追加し、ユーザーとイベントの参加登録／補欠登録の関係を管理  
  - バリデーションを設定し、既に登録済みの場合の重複登録を防止

- **コントローラの実装**  
  - `EventParticipantsController`：参加登録、新規登録、登録キャンセルの処理を実装  
  - `EventWaitlistsController`：補欠登録キャンセルの処理を実装  
  - `EventsController#show` で、関連する参加者／補欠者情報を eager loading により表示

- **サービスオブジェクト**  
  - `EventRegistrationService` を実装し、参加登録やキャンセル時のトランザクション処理と、補欠からの昇格処理を行う

- **ポリシー**  
  - `EventParticipantPolicy` および `EventWaitlistPolicy` を追加し、登録・キャンセルに対する適切なアクセス制御を実施

- **ビューの改善**  
  - イベント詳細画面に参加者一覧と補欠者一覧を表示し、登録済みの場合はキャンセルリンクを、未登録の場合は登録リンクを表示

※ 削除失敗時のエラーハンドリングについては、今後の改修で対応予定。

**テスト**  
- モデル、コントローラ、サービス、ポリシーに対するテストも追加済み。