### PR TITLE
Feat/#53 ダッシュボード機能の実装

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -3,9 +3,9 @@ class DashboardsController < ApplicationController
 
   def show
     @participating_events = current_user.participating_events
-                                      .includes(:eventable)
-                                      .where(status: 'published')
-                                      .where('event_start_at >= ?', Date.current)
+                                      .includes(:eventable, eventable: :events)
+                                      .published
+                                      .now_than_after
                                       .order(event_start_at: :asc)
                                       .limit(5)
 
@@ -18,7 +18,7 @@ class DashboardsController < ApplicationController
     @administered_events = Event.preload(:eventable)
                             .where(eventable_type: 'EventGroup',
                                    eventable_id: current_user.administered_group_ids)
-                            .where('event_start_at >= ?', Date.current)
+                            .now_than_after
                             .order(event_start_at: :asc)
                             .limit(5)
   end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,8 +1,10 @@
 class DashboardsController < ApplicationController
   before_action :authenticate_user!
 
+  # TODO: カウントに関しては、counter_cacheを使うようにする
   def show
     @participating_events = current_user.participating_events
+                                      .with_attached_image
                                       .includes(:eventable, eventable: :events)
                                       .published
                                       .now_than_after
@@ -10,12 +12,14 @@ class DashboardsController < ApplicationController
                                       .limit(5)
 
     @administered_groups = current_user.administered_groups
+                                     .with_attached_image
                                      .includes(:events)
                                      .order(created_at: :asc)
                                      .limit(5)
 
     # TODO: ユーザーイベントも含める
-    @administered_events = Event.preload(:eventable)
+    @administered_events = Event.with_attached_image
+                            .preload(:eventable)
                             .where(eventable_type: 'EventGroup',
                                    eventable_id: current_user.administered_group_ids)
                             .now_than_after

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -2,6 +2,24 @@ class DashboardsController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    # TODO
+    @participating_events = current_user.participating_events
+                                      .includes(:eventable)
+                                      .where(status: 'published')
+                                      .where('event_start_at >= ?', Date.current)
+                                      .order(event_start_at: :asc)
+                                      .limit(5)
+
+    @administered_groups = current_user.administered_groups
+                                     .includes(:events)
+                                     .order(created_at: :asc)
+                                     .limit(5)
+
+    # TODO: ユーザーイベントも含める
+    @administered_events = Event.preload(:eventable)
+                            .where(eventable_type: 'EventGroup',
+                                   eventable_id: current_user.administered_group_ids)
+                            .where('event_start_at >= ?', Date.current)
+                            .order(event_start_at: :asc)
+                            .limit(5)
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -24,6 +24,9 @@ class Event < ApplicationRecord
   validate :event_start_cannot_be_in_past, if: -> { event_start_at.present? }
   validate :recruitment_start_cannot_be_in_past, if: -> { recruitment_start_at.present? }
 
+  scope :published, -> { where(status: :published) }
+  scope :now_than_after, -> { where('event_start_at >= ?', Time.current) }
+
   def full?
     return false if max_participants.nil?
     participants.count >= max_participants

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,17 +12,17 @@ class Event < ApplicationRecord
   has_one_attached :image
 
   validates :title, presence: true
+  validates :recruitment_start_at, presence: true
   validates :event_start_at, presence: true
   validates :event_end_at, presence: true, comparison: { greater_than: :event_start_at }
-  validates :recruitment_start_at, presence: true
   validates :recruitment_closed_at, presence: true, comparison: { greater_than: :recruitment_start_at }
   validates :max_participants, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+  validate :recruitment_start_at_validation
+  validate :event_start_at_validation
+  validate :event_end_at_validation
+  validate :recruitment_closed_at_validation
 
   enum :status, { draft: 0, published: 1, closed: 2 }
-
-  validate :event_start_after_recruitment_start
-  validate :event_start_cannot_be_in_past, if: -> { event_start_at.present? }
-  validate :recruitment_start_cannot_be_in_past, if: -> { recruitment_start_at.present? }
 
   scope :published, -> { where(status: :published) }
   scope :now_than_after, -> { where('event_start_at >= ?', Time.current) }
@@ -42,22 +42,26 @@ class Event < ApplicationRecord
 
   private
 
-  def event_start_after_recruitment_start
-    return if event_start_at.blank? || recruitment_start_at.blank?
-    return unless event_start_at < recruitment_start_at
-
-    errors.add(:event_start_at, "は募集開始日以降の日付にしてください。")
+  def recruitment_start_at_validation
+    errors.add(:recruitment_start_at, "は現在日時以降にしてください。") if recruitment_start_at < Time.current
   end
 
-  def event_start_cannot_be_in_past
-    return unless event_start_at < Date.today
+  def event_start_at_validation
+    if event_start_at < Time.current
+      errors.add(:event_start_at, "は現在日時以降にしてください。")
+      return
+    end
 
-    errors.add(:event_start_at, "は今日以降の日付にしてください。")
+    if event_start_at < recruitment_start_at
+      errors.add(:event_start_at, "は募集開始日時以降にしてください。")
+    end
   end
 
-  def recruitment_start_cannot_be_in_past
-    return unless recruitment_start_at < Date.today
+  def event_end_at_validation
+    errors.add(:event_end_at, "はイベント開始日時より後の日時にしてください。") if event_end_at <= event_start_at
+  end
 
-    errors.add(:recruitment_start_at, "は今日以降の日付にしてください。")
+  def recruitment_closed_at_validation
+    errors.add(:recruitment_closed_at, "は募集開始日時より後の日時にしてください。") if recruitment_closed_at <= recruitment_start_at
   end
 end

--- a/app/views/dashboards/_event_card.html.erb
+++ b/app/views/dashboards/_event_card.html.erb
@@ -1,0 +1,28 @@
+<div class="bg-white rounded-lg shadow-md p-4 hover:shadow-lg transition-shadow">
+  <div class="flex gap-4">
+    <div class="flex-shrink-0 w-24 h-24 flex flex-col">
+      <% if event.image.attached? %>
+        <%= image_tag event.image, class: "w-full h-[80%] object-cover rounded-t-lg" %>
+      <% else %>
+        <div class="w-full h-[80%] bg-gray-200 rounded-t-lg flex items-center justify-center">
+          <span class="text-gray-400 text-xs">画像がありません</span>
+        </div>
+      <% end %>
+      <div class="w-full h-[20%] bg-[var(--color-pastel-pink)] bg-opacity-70 text-white text-xs flex items-center justify-center rounded-b-lg">
+        <%= event.event_start_at.strftime("%m/%d") %>
+      </div>
+    </div>
+    <div class="flex-grow">
+      <div class="flex justify-between items-center">
+        <h4 class="text-lg font-bold text-[var(--color-pastel-purple)]"><%= link_to event.title, event_path(event), class: "hover:underline" %></h4>
+      </div>
+      <div class="text-sm text-[var(--color-pastel-brown)]">
+        <p>開催時間：<%= event.event_start_at.strftime("%H:%M") %>〜<%= event.event_end_at.strftime("%H:%M") %></p>
+        <p>場所：<%= event.location.blank? ? "指定なし" : event.location %></p>
+      </div>
+      <div class="text-right mt-2">
+        <span class="text-[var(--color-pastel-brown)]">参加者: <%= event.participants.count %> 名</span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -2,9 +2,47 @@
   <h2 class="text-3xl font-bold text-[var(--color-pastel-purple)]">ダッシュボード</h2>
   
   <div>
-    <h3 class="text-2xl font-bold text-[var(--color-pastel-purple)]">参加予定のイベント一覧</h3>
-    TODO
-    <h3 class="text-2xl font-bold text-[var(--color-pastel-purple)]">管理者となってるグループのイベント一覧</h3>
-    TODO
+    <div class="border border-[var(--color-pastel-pink)] rounded-lg p-4 mb-8 shadow-sm bg-white/50">
+      <h3 class="text-2xl font-bold text-[var(--color-pastel-purple)] mb-4">参加予定のイベント一覧</h3>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <% @participating_events.each do |event| %>
+          <%= render "event_card", event: event %>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="border border-[var(--color-pastel-pink)] rounded-lg p-4 mb-8 shadow-sm bg-white/50">
+      <h3 class="text-2xl font-bold text-[var(--color-pastel-purple)] mb-4">主催イベント一覧</h3>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <% @administered_events.each do |event| %>
+          <%= render "event_card", event: event %>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="border border-[var(--color-pastel-pink)] rounded-lg p-4 mb-8 shadow-sm bg-white/50">
+      <h3 class="text-2xl font-bold text-[var(--color-pastel-purple)] mb-4">管理者となってるグループ一覧</h3>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <% @administered_groups.each do |group| %>
+          <div class="bg-white rounded-lg shadow-md p-4 hover:shadow-lg transition-shadow">
+            <div class="flex gap-4">
+              <div class="flex-shrink-0 w-24 h-24">
+                <% if group.image.attached? %>
+                  <%= image_tag group.image, class: "w-full h-full object-cover rounded-lg" %>
+                <% else %>
+                  <div class="w-full h-full bg-gray-200 rounded-lg flex items-center justify-center">
+                    <span class="text-gray-400 text-xs">画像がありません</span>
+                  </div>
+                <% end %>
+              </div>
+              <div>
+                <h4 class="text-lg font-bold text-[var(--color-pastel-purple)]"><%= link_to group.name, event_group_path(group), class: "hover:underline" %></h4>
+                <p><%= group.description %></p>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -51,19 +51,19 @@
 
     <div>
       <h3 class="text-[var(--color-pastel-brown)] text-lg font-bold">イベント開始日時:</h3>
-      <p><%= @event.event_start_at %></p>
+      <p><%= l @event.event_start_at, format: :long  %></p>
     </div>
     <div>
       <h3 class="text-[var(--color-pastel-brown)] text-lg font-bold">イベント終了日時:</h3>
-      <p><%= @event.event_end_at %></p>
+      <p><%= l @event.event_end_at, format: :long  %></p>
     </div>
     <div>
       <h3 class="text-[var(--color-pastel-brown)] text-lg font-bold">募集開始日時:</h3>
-      <p><%= @event.recruitment_start_at %></p>
+      <p><%= l @event.recruitment_start_at, format: :long  %></p>
     </div>
     <div>
       <h3 class="text-[var(--color-pastel-brown)] text-lg font-bold">募集終了日時:</h3>
-      <p><%= @event.recruitment_closed_at %></p>
+      <p><%= l @event.recruitment_closed_at, format: :long  %></p>
     </div>
     <div>
       <h3 class="text-[var(--color-pastel-brown)] text-lg font-bold">場所:</h3>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,10 +49,11 @@ event_groups.each do |group|
   # グループごとに2つのイベントを作成
   2.times do |n|
     # 時間の設定をバリエーション付きで
-    start_time = Time.current + (n+1).days + n.hours
+    current_time = Time.current
+    recruitment_start = current_time + 1.hour + n.hours  # 現在時刻から十分に未来の時間を設定
+    start_time = recruitment_start + n.hours
     end_time = start_time + 2.hours
-    recruitment_start = Time.current + n.hours
-    recruitment_end = start_time - 1.hour
+    recruitment_end = end_time + 1.hour
 
     # ステータスをバリエーション付きで
     status = case n

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,42 +1,21 @@
 FactoryBot.define do
   factory :event do
     sequence(:title) { |n| "テストイベント#{n}" }
-    event_start_at { Date.current + 1.day }
-    event_end_at { Date.current + 2.days }
-    recruitment_start_at { Date.current }
-    recruitment_closed_at { Date.current + 1.day }
+    recruitment_start_at { Time.current + 1.minute }
+    event_start_at { recruitment_start_at + 1.minute }
+    event_end_at { event_start_at + 1.hour }
+    recruitment_closed_at { recruitment_start_at + 30.minutes }
     max_participants { 10 }
     status { :draft }
     association :eventable, factory: :event_group
 
-    # 過去のイベント
     trait :past do
-      to_create do |event|
-        event.save(validate: false)
-        event.update_columns(
-          event_start_at: 1.week.ago,
-          event_end_at: 6.days.ago,
-          recruitment_start_at: 2.weeks.ago,
-          recruitment_closed_at: 1.week.ago,
-          status: 'closed'
-        )
-      end
-    end
+      event_start_at { Time.current - 1.day }
+      event_end_at { Time.current - 12.hours }
+      recruitment_start_at { Time.current - 2.days }
+      recruitment_closed_at { Time.current - 1.day }
 
-    # 開催中のイベント
-    trait :ongoing do
-      status { :published }
-      event_start_at { Date.current }
-      event_end_at { Date.current + 1.day }
-    end
-
-    # 未来のイベント
-    trait :future do
-      status { :published }
-      recruitment_start_at { Date.current }
-      recruitment_closed_at { Date.current + 1.week }
-      event_start_at { Date.current + 1.week }
-      event_end_at { Date.current + 1.week + 1.day }
+      to_create { |instance| instance.save(validate: false) }
     end
 
     # 個人イベント

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :event do
-    title { "テストイベント" }
+    sequence(:title) { |n| "テストイベント#{n}" }
     event_start_at { Date.current + 1.day }
     event_end_at { Date.current + 2.days }
     recruitment_start_at { Date.current }
@@ -9,10 +9,39 @@ FactoryBot.define do
     status { :draft }
     association :eventable, factory: :event_group
 
-    # TODO:  個人イベントを追加するためのトレイト
+    # 過去のイベント
+    trait :past do
+      to_create do |event|
+        event.save(validate: false)
+        event.update_columns(
+          event_start_at: 1.week.ago,
+          event_end_at: 6.days.ago,
+          recruitment_start_at: 2.weeks.ago,
+          recruitment_closed_at: 1.week.ago,
+          status: 'closed'
+        )
+      end
+    end
 
-    trait :group do
-      association :eventable, factory: :event_group
+    # 開催中のイベント
+    trait :ongoing do
+      status { :published }
+      event_start_at { Date.current }
+      event_end_at { Date.current + 1.day }
+    end
+
+    # 未来のイベント
+    trait :future do
+      status { :published }
+      recruitment_start_at { Date.current }
+      recruitment_closed_at { Date.current + 1.week }
+      event_start_at { Date.current + 1.week }
+      event_end_at { Date.current + 1.week + 1.day }
+    end
+
+    # 個人イベント
+    trait :personal do
+      association :eventable, factory: :user
     end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -11,64 +11,206 @@ RSpec.describe Event, type: :model do
     expect(Event.statuses).to eq({ "draft" => 0, "published" => 1, "closed" => 2 })
   end
 
-  describe "日付関連のバリデーション" do
-    let(:yesterday) { Date.current - 1.day }
-    let(:today) { Date.current }
-    let(:tomorrow) { Date.current + 1.day }
-    let(:day_after_tomorrow) { Date.current + 2.days }
+  describe "日時関連のバリデーション" do
+    around do |example|
+      travel_to Time.zone.local(2025, 4, 1, 12, 0, 0)
+      example.run
+      travel_back
+    end
 
-    context "イベント開始日のバリデーション" do
-      it "イベント開始日が募集開始日より前の場合、適切なエラーメッセージが表示されること" do
-        event = build(:event,
-          event_start_at: today,
-          recruitment_start_at: tomorrow
-        )
-        expect(event).not_to be_valid
-        expect(event.errors[:event_start_at]).to include("は募集開始日以降の日付にしてください。")
+    let(:base_time) { Time.current }
+    let(:past) { base_time - 1.second }
+    let(:now) { base_time }
+    let(:future) { base_time + 1.second }
+    let(:far_future) { base_time + 1.hour }
+
+    let(:valid_contexts) do
+      {
+        # 基本ケース：全て最小限の有効な値
+        basic: {
+          recruitment_start_at: now,
+          event_start_at: now,
+          recruitment_closed_at: future,
+          event_end_at: future
+        },
+        # 全て未来の異なる時刻
+        all_different_times: {
+          recruitment_start_at: now,
+          event_start_at: now + 1.minute,
+          recruitment_closed_at: now + 2.minutes,
+          event_end_at: now + 3.minutes
+        },
+        # 同時刻境界ケース：開始が同時
+        same_start_times: {
+          recruitment_start_at: now,
+          event_start_at: now,
+          recruitment_closed_at: future,
+          event_end_at: far_future
+        },
+        # 同時刻境界ケース：終了が同時でない（異なる値）
+        different_end_times: {
+          recruitment_start_at: now,
+          event_start_at: now,
+          recruitment_closed_at: future,
+          event_end_at: far_future
+        }
+      }
+    end
+
+    # バリデーション検証の独自ヘルパーメソッド
+    def build_event_with_dates(context, overrides = {})
+      params = valid_contexts[context].merge(overrides)
+      build(:event, params)
+    end
+
+    # 属性とエラーメッセージのマッピング
+    let(:validation_messages) do
+      {
+        recruitment_start_at_past: {
+          attribute: :recruitment_start_at,
+          message: "は現在日時以降にしてください。"
+        },
+        event_start_at_past: {
+          attribute: :event_start_at,
+          message: "は現在日時以降にしてください。"
+        },
+        event_start_before_recruitment: {
+          attribute: :event_start_at,
+          message: "は募集開始日時以降にしてください。"
+        },
+        event_end_not_after_start: {
+          attribute: :event_end_at,
+          message: "はイベント開始日時より後の日時にしてください。"
+        },
+        recruitment_closed_not_after_start: {
+          attribute: :recruitment_closed_at,
+          message: "は募集開始日時より後の日時にしてください。"
+        }
+      }
+    end
+
+    context "単一の日時フィールドのバリデーション" do
+      describe "募集開始日時のバリデーション" do
+        it "現在より過去の場合はエラー" do
+          event = build_event_with_dates(:basic, recruitment_start_at: past)
+          expect(event).not_to be_valid
+          expect(event.errors[validation_messages[:recruitment_start_at_past][:attribute]])
+            .to include(validation_messages[:recruitment_start_at_past][:message])
+        end
+
+        it "現在時刻以降なら有効" do
+          event = build_event_with_dates(:basic)
+          expect(event).to be_valid
+        end
       end
 
-      it "イベント開始日が現在日時より過去の場合、適切なエラーメッセージが表示されること" do
-        event = build(:event, event_start_at: yesterday)
-        expect(event).not_to be_valid
-        expect(event.errors[:event_start_at]).to include("は今日以降の日付にしてください。")
+      describe "イベント開始日時のバリデーション" do
+        it "現在より過去の場合はエラー" do
+          event = build_event_with_dates(:basic, event_start_at: past)
+          expect(event).not_to be_valid
+          expect(event.errors[validation_messages[:event_start_at_past][:attribute]])
+            .to include(validation_messages[:event_start_at_past][:message])
+        end
+
+        it "募集開始より前の場合はエラー" do
+          event = build_event_with_dates(:basic,
+            recruitment_start_at: future,
+            event_start_at: now,
+            recruitment_closed_at: far_future,
+            event_end_at: far_future
+          )
+          expect(event).not_to be_valid
+          expect(event.errors[validation_messages[:event_start_before_recruitment][:attribute]])
+            .to include(validation_messages[:event_start_before_recruitment][:message])
+        end
+
+        it "募集開始と同じ時刻なら有効" do
+          event = build_event_with_dates(:same_start_times)
+          expect(event).to be_valid
+        end
+
+        it "募集開始より後なら有効" do
+          event = build_event_with_dates(:all_different_times)
+          expect(event).to be_valid
+        end
       end
     end
 
-    context "募集開始日のバリデーション" do
-      it "募集開始日が現在日時より過去の場合、適切なエラーメッセージが表示されること" do
-        event = build(:event, recruitment_start_at: yesterday)
-        expect(event).not_to be_valid
-        expect(event.errors[:recruitment_start_at]).to include("は今日以降の日付にしてください。")
+    context "日時の前後関係のバリデーション" do
+      describe "イベント終了日時のバリデーション" do
+        it "イベント開始より前の場合はエラー" do
+          event = build_event_with_dates(:basic,
+            event_start_at: future,
+            event_end_at: now
+          )
+          expect(event).not_to be_valid
+          expect(event.errors[validation_messages[:event_end_not_after_start][:attribute]])
+            .to include(validation_messages[:event_end_not_after_start][:message])
+        end
+
+        it "イベント開始と同じ場合はエラー" do
+          event = build_event_with_dates(:basic,
+            event_start_at: now,
+            event_end_at: now
+          )
+          expect(event).not_to be_valid
+          expect(event.errors[validation_messages[:event_end_not_after_start][:attribute]])
+            .to include(validation_messages[:event_end_not_after_start][:message])
+        end
+
+        it "イベント開始より後なら有効" do
+          event = build_event_with_dates(:basic)
+          expect(event).to be_valid
+        end
+      end
+
+      describe "募集終了日時のバリデーション" do
+        it "募集開始より前の場合はエラー" do
+          event = build_event_with_dates(:basic,
+            recruitment_start_at: future,
+            recruitment_closed_at: now,
+            event_start_at: future,
+            event_end_at: far_future
+          )
+          expect(event).not_to be_valid
+          expect(event.errors[validation_messages[:recruitment_closed_not_after_start][:attribute]])
+            .to include(validation_messages[:recruitment_closed_not_after_start][:message])
+        end
+
+        it "募集開始と同じ場合はエラー" do
+          event = build_event_with_dates(:basic,
+            recruitment_start_at: now,
+            recruitment_closed_at: now,
+            event_start_at: now,
+            event_end_at: future
+          )
+          expect(event).not_to be_valid
+          expect(event.errors[validation_messages[:recruitment_closed_not_after_start][:attribute]])
+            .to include(validation_messages[:recruitment_closed_not_after_start][:message])
+        end
+
+        it "募集開始より後なら有効" do
+          event = build_event_with_dates(:basic)
+          expect(event).to be_valid
+        end
       end
     end
 
-    context "同じ日付の場合の挙動" do
-      it "イベント開始日と募集開始日が同じ場合、有効であること" do
-        event = build(:event,
-          event_start_at: today,
-          recruitment_start_at: today
-        )
+    context "複合的なケース" do
+      it "すべての日時が適切な順序で設定されていれば有効" do
+        event = build_event_with_dates(:all_different_times)
         expect(event).to be_valid
       end
-    end
 
-    context "終了日のバリデーション" do
-      it "イベント終了日が開始日より前の場合、適切なエラーメッセージが表示されること" do
-        event = build(:event,
-          event_start_at: today,
-          event_end_at: yesterday
+      it "複数の日時が無効な状態にあると複数のエラーが返される" do
+        event = build_event_with_dates(:basic,
+          recruitment_start_at: future,  # 未来に設定
+          event_start_at: now,           # 募集開始より前になってしまう
+          recruitment_closed_at: now,    # 募集開始より前になってしまう
+          event_end_at: now              # イベント開始と同じになってしまう
         )
         expect(event).not_to be_valid
-        expect(event.errors[:event_end_at]).to include("はイベント開始日時より後の日時にしてください。")
-      end
-
-      it "募集終了日が開始日より前の場合、適切なエラーメッセージが表示されること" do
-        event = build(:event,
-          recruitment_start_at: today,
-          recruitment_closed_at: yesterday
-        )
-        expect(event).not_to be_valid
-        expect(event.errors[:recruitment_closed_at]).to include("は募集開始日時より後の日時にしてください。")
+        expect(event.errors.size).to be >= 2
       end
     end
   end
@@ -119,6 +261,130 @@ RSpec.describe Event, type: :model do
       event.image.attach(test_image)
       expect(event.image).to be_attached
       expect(event.image.content_type).to eq('image/jpeg')
+    end
+  end
+
+  describe "scopes" do
+    describe ".published" do
+      let!(:draft_event) { create(:event, status: :draft) }
+      let!(:published_event) { create(:event, status: :published) }
+      let!(:closed_event) { create(:event, status: :closed) }
+
+      it "公開状態のイベントのみを返すこと" do
+        expect(Event.published).to include(published_event)
+        expect(Event.published).not_to include(draft_event, closed_event)
+      end
+    end
+
+    describe ".now_than_after" do
+      around do |example|
+        travel_to Time.zone.local(2025, 4, 1, 12, 0, 0)
+        example.run
+        travel_back
+      end
+
+      let!(:past_event) do
+        event = build(:event, event_start_at: Time.current - 1.second)
+        event.save(validate: false) # 現在日時より前の時刻をイベント開始日時にできないので、バリデーションをスキップ
+        event
+      end
+      let!(:current_event) do
+        event = build(:event, recruitment_start_at: Time.current - 1.second, event_start_at: Time.current)
+        event.save(validate: false) # 募集開始日時をイベント開始日時前にできないので、バリデーションをスキップ
+        event
+      end
+      let!(:future_event) { create(:event, recruitment_start_at: Time.current, event_start_at: Time.current + 1.second) }
+
+      it "現在時刻以降に開始するイベントのみを返すこと" do
+        expect(Event.now_than_after).to include(current_event, future_event)
+        expect(Event.now_than_after).not_to include(past_event)
+      end
+    end
+  end
+
+  describe "インスタンスメソッド" do
+    let(:user) { create(:user) }
+    let(:another_user) { create(:user) }
+
+    describe "#full?" do
+      context "定員が設定されていない場合" do
+        let(:event) { create(:event, max_participants: nil) }
+
+        it "常にfalseを返すこと" do
+          expect(event.full?).to be false
+
+          5.times { event.participants << create(:user) }
+          expect(event.full?).to be false
+        end
+      end
+
+      context "定員が設定されている場合" do
+        let(:event) { create(:event, max_participants: 3) }
+
+        it "参加者数が定員未満ならfalseを返すこと" do
+          event.participants << user
+          expect(event.full?).to be false
+
+          event.participants << another_user
+          expect(event.full?).to be false
+        end
+
+        it "参加者数が定員に達したらtrueを返すこと" do
+          3.times { event.participants << create(:user) }
+          expect(event.full?).to be true
+        end
+      end
+    end
+
+    describe "#registered?" do
+      let(:event) { create(:event) }
+
+      context "ユーザーがイベントに参加登録している場合" do
+        it "trueを返すこと" do
+          event.participants << user
+          expect(event.registered?(user)).to be true
+        end
+      end
+
+      context "ユーザーがイベントのキャンセル待ちリストに登録されている場合" do
+        it "trueを返すこと" do
+          event.waitlisted_users << user
+          expect(event.registered?(user)).to be true
+        end
+      end
+
+      context "ユーザーがイベントに登録されていない場合" do
+        it "falseを返すこと" do
+          expect(event.registered?(user)).to be false
+        end
+      end
+    end
+
+    describe "#registration_for" do
+      let(:event) { create(:event) }
+      let!(:participant) { create(:event_participant, event: event, user: user) }
+
+      context "ユーザーが参加者の場合" do
+        it "EventParticipantインスタンスを返すこと" do
+          expect(event.registration_for(user)).to eq(participant)
+        end
+      end
+
+      context "ユーザーがキャンセル待ちの場合" do
+        let!(:waitlist) { create(:event_waitlist, event: event, user: another_user) }
+
+        it "EventWaitlistインスタンスを返すこと" do
+          expect(event.registration_for(another_user)).to eq(waitlist)
+        end
+      end
+
+      context "ユーザーが登録されていない場合" do
+        let(:unregistered_user) { create(:user) }
+
+        it "nilを返すこと" do
+          expect(event.registration_for(unregistered_user)).to be_nil
+        end
+      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,8 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require "pundit/rspec"
 
+require 'active_support/testing/time_helpers'
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end
@@ -79,4 +81,6 @@ RSpec.configure do |config|
   ActiveSupport.on_load(:action_mailer) do
     Rails.application.reload_routes_unless_loaded
   end
+
+  config.include ActiveSupport::Testing::TimeHelpers
 end

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -11,14 +11,28 @@ RSpec.describe "Dashboards", type: :request do
 
     context 'サインインしている場合' do
       let(:user) { create(:user) }
+      let(:event_group) { create(:event_group) }
+      let(:future_group_event) { create(:event, :future, eventable: event_group) }
+      let(:ongoing_group_event) { create(:event, :ongoing, eventable: event_group) }
+      let(:past_group_event) { create(:event, :past, eventable: event_group) }
 
       before do
         sign_in user
+        create(:event_participant, event: future_group_event, user: user)
+        create(:event_participant, event: ongoing_group_event, user: user)
+        create(:event_participant, event: past_group_event, user: user)
       end
 
       it 'レスポンスが成功すること' do
         get dashboard_path
         expect(response).to have_http_status(200)
+      end
+
+      it '適切なイベントが表示されていること' do
+        get dashboard_path
+        expect(response.body).to include(future_group_event.title)
+        expect(response.body).to include(ongoing_group_event.title)
+        expect(response.body).not_to include(past_group_event.title)
       end
     end
   end

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -12,14 +12,12 @@ RSpec.describe "Dashboards", type: :request do
     context 'サインインしている場合' do
       let(:user) { create(:user) }
       let(:event_group) { create(:event_group) }
-      let(:future_group_event) { create(:event, :future, eventable: event_group) }
-      let(:ongoing_group_event) { create(:event, :ongoing, eventable: event_group) }
+      let(:now_than_after_group_event) { create(:event, eventable: event_group, status: :published) }
       let(:past_group_event) { create(:event, :past, eventable: event_group) }
 
       before do
         sign_in user
-        create(:event_participant, event: future_group_event, user: user)
-        create(:event_participant, event: ongoing_group_event, user: user)
+        create(:event_participant, event: now_than_after_group_event, user: user)
         create(:event_participant, event: past_group_event, user: user)
       end
 
@@ -30,8 +28,7 @@ RSpec.describe "Dashboards", type: :request do
 
       it '適切なイベントが表示されていること' do
         get dashboard_path
-        expect(response.body).to include(future_group_event.title)
-        expect(response.body).to include(ongoing_group_event.title)
+        expect(response.body).to include(now_than_after_group_event.title)
         expect(response.body).not_to include(past_group_event.title)
       end
     end

--- a/spec/requests/event_spec.rb
+++ b/spec/requests/event_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Events", type: :request do
       title: 'New Event',
       event_start_at: Time.current + 1.day,
       event_end_at: Time.current + 2.days,
-      recruitment_start_at: Time.current,
+      recruitment_start_at: Time.current + 1.minute,
       recruitment_closed_at: Time.current + 1.day,
       max_participants: 10
     }


### PR DESCRIPTION
## やったこと
Issue: #53 

- ダッシュボード画面のUI実装完了
  - ユーザーが参加予定のイベント一覧を表示
  - 管理者となっているグループ一覧を表示
  - 主催イベント一覧を表示


イベントのファクトリに トレイトを追加

```mermaid
graph LR
    subgraph "イベント日時の制約関係"
        NOW[現在時刻]
        RS[募集開始日時 recruitment_start_at]
        ES[イベント開始日時 event_start_at]
        RC[募集終了日時 recruitment_closed_at]
        EE[イベント終了日時 event_end_at]

        NOW -->|以降であること| RS
        NOW -->|以降であること| ES
        RS -->|以降であること| ES
        RS -->|より後であること| RC
        ES -->|より後であること| EE
    end
```