### PR TITLE
Fix nil handling in Event date validations

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -43,14 +43,20 @@ class Event < ApplicationRecord
   private
 
   def recruitment_start_at_validation
+    return if recruitment_start_at.blank?
+
     errors.add(:recruitment_start_at, "は現在日時以降にしてください。") if recruitment_start_at < Time.current
   end
 
   def event_start_at_validation
+    return if event_start_at.blank?
+
     if event_start_at < Time.current
       errors.add(:event_start_at, "は現在日時以降にしてください。")
       return
     end
+
+    return if recruitment_start_at.blank?
 
     if event_start_at < recruitment_start_at
       errors.add(:event_start_at, "は募集開始日時以降にしてください。")
@@ -58,10 +64,14 @@ class Event < ApplicationRecord
   end
 
   def event_end_at_validation
+    return if event_end_at.blank? || event_start_at.blank?
+
     errors.add(:event_end_at, "はイベント開始日時より後の日時にしてください。") if event_end_at <= event_start_at
   end
 
   def recruitment_closed_at_validation
+    return if recruitment_closed_at.blank? || recruitment_start_at.blank?
+
     errors.add(:recruitment_closed_at, "は募集開始日時より後の日時にしてください。") if recruitment_closed_at <= recruitment_start_at
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -7,6 +7,22 @@ RSpec.describe Event, type: :model do
     expect(event.errors[:title]).to include("を入力してください。")
   end
 
+  it "必須の日時項目がnilでもバリデーションで例外が発生しないこと" do
+    event = build(
+      :event,
+      recruitment_start_at: nil,
+      event_start_at: nil,
+      event_end_at: nil,
+      recruitment_closed_at: nil
+    )
+
+    expect { event.valid? }.not_to raise_error
+    expect(event.errors[:recruitment_start_at]).to include("を入力してください。")
+    expect(event.errors[:event_start_at]).to include("を入力してください。")
+    expect(event.errors[:event_end_at]).to include("を入力してください。")
+    expect(event.errors[:recruitment_closed_at]).to include("を入力してください。")
+  end
+
   it "正しいenum値を持つこと" do
     expect(Event.statuses).to eq({ "draft" => 0, "published" => 1, "closed" => 2 })
   end


### PR DESCRIPTION
## Summary
- prevent `NoMethodError` when date fields are nil in `Event` model validations
- add spec confirming no exception is raised when required date attributes are missing

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68b28bd174088328a2e742a1e1d12fed