### PR TITLE
Update Brakeman to latest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", require: false
+  gem "brakeman", "~> 7.1", require: false
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.0.2)
+    brakeman (7.1.0)
       racc
     builder (3.3.0)
     capybara (3.40.0)
@@ -442,7 +442,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
-  brakeman
+  brakeman (~> 7.1)
   capybara
   debug
   devise (= 4.9.4)


### PR DESCRIPTION
## Summary
- Update Brakeman gem to ~> 7.1 to align with latest release

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bin/brakeman --no-pager` *(fails: Bundler::GemNotFound: Could not find required gems)*

------
https://chatgpt.com/codex/tasks/task_e_68b28d88e6108328a76a8d2983856a98