### PR TITLE
EventGroupAdmin のオーナー削除判定を Policy に移動

### DIFF
--- a/app/controllers/event_group_admins_controller.rb
+++ b/app/controllers/event_group_admins_controller.rb
@@ -26,19 +26,14 @@ class EventGroupAdminsController < ApplicationController
   def destroy
     authorize event_group_admin
 
-    event_group = event_group_admin.event_group
-    target_user = event_group_admin.user
-
-    if event_group.owner?(target_user)
-      flash[:alert] = 'オーナーは削除できません。'
-      redirect_to event_group_event_group_admins_path(event_group), status: :see_other
+    if event_group_admin.destroy
     else
-      if event_group_admin.destroy
-      else
-        flash[:alert] = '削除に失敗しました。'
-        redirect_to event_group_event_group_admins_path(event_group), status: :see_other
-      end
+      flash[:alert] = '削除に失敗しました。'
+      redirect_to event_group_event_group_admins_path(event_group_admin.event_group), status: :see_other
     end
+  rescue Pundit::NotAuthorizedError
+    flash[:alert] = 'オーナーは削除できません。'
+    redirect_to event_group_event_group_admins_path(event_group_admin.event_group), status: :see_other
   end
 
   private

--- a/app/policies/event_group_admin_policy.rb
+++ b/app/policies/event_group_admin_policy.rb
@@ -15,6 +15,6 @@ class EventGroupAdminPolicy < ApplicationPolicy
   end
 
   def destroy?
-    record.event_group.admin?(user)
+    record.event_group.admin?(user) && !record.event_group.owner?(record.user)
   end
 end

--- a/spec/policies/event_group_admin_policy_spec.rb
+++ b/spec/policies/event_group_admin_policy_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe EventGroupAdminPolicy do
+  subject { described_class.new(user, event_group_admin) }
+
+  let(:owner) { create(:user) }
+  let(:event_group) { create(:event_group, user: owner) }
+
+  context '管理者の場合' do
+    let(:user) { admin_user }
+    let(:admin_user) { create(:user) }
+    let!(:admin_record) { create(:event_group_admin, user: admin_user, event_group: event_group) }
+
+    context '削除対象がオーナーでない場合' do
+      let(:event_group_admin) { create(:event_group_admin, event_group: event_group, user: create(:user)) }
+
+      it { is_expected.to permit_actions(%i[destroy]) }
+    end
+
+    context '削除対象がオーナーの場合' do
+      let(:event_group_admin) { event_group.event_group_admins.find_by(user: owner) }
+
+      it { is_expected.to forbid_actions(%i[destroy]) }
+    end
+  end
+
+  context '管理者でない場合' do
+    let(:user) { create(:user) }
+    let(:event_group_admin) { create(:event_group_admin, event_group: event_group, user: create(:user)) }
+
+    it { is_expected.to forbid_actions(%i[destroy]) }
+  end
+end
+

--- a/spec/requests/event_group_admins_spec.rb
+++ b/spec/requests/event_group_admins_spec.rb
@@ -1,7 +1,42 @@
 require 'rails_helper'
 
-RSpec.describe "EventGroupAdmins", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+RSpec.describe 'EventGroupAdmins', type: :request do
+  describe 'DELETE /destroy' do
+    let(:owner) { create(:user) }
+    let(:event_group) { create(:event_group, user: owner) }
+    let(:headers) { { 'ACCEPT' => 'text/vnd.turbo-stream.html' } }
+
+    context 'オーナーを削除しようとした場合' do
+      let(:admin_user) { create(:user) }
+      let!(:admin_record) { create(:event_group_admin, user: admin_user, event_group: event_group) }
+      let(:owner_admin) { event_group.event_group_admins.find_by(user: owner) }
+
+      before { sign_in admin_user }
+
+      it '削除されずフラッシュメッセージが表示されること' do
+        expect do
+          delete event_group_event_group_admin_path(event_group, owner_admin), headers: headers
+        end.not_to change(EventGroupAdmin, :count)
+
+        expect(flash[:alert]).to eq('オーナーは削除できません。')
+        expect(response).to redirect_to(event_group_event_group_admins_path(event_group))
+      end
+    end
+
+    context '他の管理者を削除する場合' do
+      let(:admin_user) { owner }
+      let(:event_group_admin) { create(:event_group_admin, event_group: event_group, user: create(:user)) }
+
+      before { sign_in admin_user }
+
+      it '削除されること' do
+        expect do
+          delete event_group_event_group_admin_path(event_group, event_group_admin), headers: headers
+        end.to change(EventGroupAdmin, :count).by(-1)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 end
+


### PR DESCRIPTION
## Summary
- prevent removing group owners via `EventGroupAdminPolicy#destroy?`
- simplify `EventGroupAdminsController#destroy` and rely on policy for owner checks
- add policy and request specs for deleting event group admins

## Testing
- `bundle exec rubocop --format progress` *(fails: bundler: command not found: rubocop)*
- `bundle exec rspec spec/policies/event_group_admin_policy_spec.rb spec/requests/event_group_admins_spec.rb` *(fails: bundler: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_68b28c81f3f0832891d3bac30d6a8b9f